### PR TITLE
Added '.d' declaration sub-extension to the PlugPlugExternalObject path

### DIFF
--- a/src/jsx/tsconfig.json
+++ b/src/jsx/tsconfig.json
@@ -6,12 +6,18 @@
     "allowJs": true,
     "strict": true,
     "noLib": true,
-    "types": ["AfterEffects/2018", "node"],
-    "typeRoots": ["../../node_modules/types-for-adobe", "./typings"]
+    "types": [
+      "AfterEffects/2018",
+      "node"
+    ],
+    "typeRoots": [
+      "../../node_modules/types-for-adobe",
+      "./typings"
+    ]
   },
   "include": [
     "./**/*",
-    "../../node_modules/types-for-adobe/shared/PlugPlugExternalObject.ts",
+    "../../node_modules/types-for-adobe/shared/PlugPlugExternalObject.d.ts",
     "../../node_modules/extendscript-es5-shim-ts/index.d.ts"
   ]
 }


### PR DESCRIPTION
The path to the PlugPlugExternalObject type declaration file in ./src/jsx/tsconfig.json []include was missing the '.d' sub-extension in the path string.